### PR TITLE
Allow specifying a document type separate from the model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,33 @@ You need to explicitly define the singular and plural forms of your entities, be
 
 Once you call `setSchema`, your `db` will be blessed with a `rel` object, which is where you can start using the rest of this plugin's API.
 
+#### documentType
+
+Rarely, you might want to have two different views over the same underlying data. Use `documentType` to create a view which reads the same data as another type:
+
+```js
+var db = new PouchDB('mydb');
+db.setSchema([
+  {
+    singular: 'post',
+    plural: 'posts',
+    relations: {
+      author: {belongsTo: 'author'},
+      comments: {hasMany: 'comment'}
+    }
+  },
+  {
+    singular: 'postSummary',
+    plural: 'postSummaries',
+    documentType: 'post'
+  }
+]);
+```
+
+Here, when you load a "postSummary", it will return the same core record as "post", but will not resolve the relationships.
+
+Be careful when using this feature — it is probably best to treat a type declaring a documentType as read-only. Do all creates/updates via the main type.
+
 ### db.rel.save(type, object)
 
 Save an object with a particular type. This returns a Promise.

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,11 @@ exports.setSchema = function (schema) {
     keysToSchemas.set(type.plural, type);
   });
 
+  // set default documentType
+  schema.forEach(function (type) {
+    type.documentType = type.documentType || type.singular;
+  });
+
   // validate the relations
   schema.forEach(function (type) {
     if (type.relations) {
@@ -116,7 +121,7 @@ exports.setSchema = function (schema) {
 
     var id = obj.id || uuid();
     delete obj.id;
-    doc._id = serialize(typeInfo.singular, id);
+    doc._id = serialize(typeInfo.documentType, id);
 
     if (typeInfo.relations) {
       Object.keys(typeInfo.relations).forEach(function (field) {
@@ -210,16 +215,16 @@ exports.setSchema = function (schema) {
 
     if (typeof idOrIds === 'undefined' || idOrIds === null) {
       // find everything
-      opts.startkey = serialize(typeInfo.singular);
-      opts.endkey = serialize(typeInfo.singular, {});
+      opts.startkey = serialize(typeInfo.documentType);
+      opts.endkey = serialize(typeInfo.documentType, {});
     } else if (Array.isArray(idOrIds)) {
       // find multiple by ids
       opts.keys = idOrIds.map(function (id) {
-        return serialize(typeInfo.singular, id);
+        return serialize(typeInfo.documentType, id);
       });
     } else {
     // find by single id
-      opts.key = serialize(typeInfo.singular, idOrIds);
+      opts.key = serialize(typeInfo.documentType, idOrIds);
     }
 
     if (!foundObjects.has(type)) {
@@ -387,6 +392,16 @@ exports.setSchema = function (schema) {
     var idx = str.indexOf('_');
     var type = str.substring(0, idx);
     var relId = deserialize(str);
+
+    var defaultType = keysToSchemas.get(type);
+    if (!defaultType) {
+      var matchingSchemaTypes = schema.filter(
+        function (schemaType) { return schemaType.documentType === type; });
+      if (matchingSchemaTypes.length > 0) {
+        type = matchingSchemaTypes[0].singular;
+      }
+    }
+
     return {
       type: type,
       id: relId
@@ -394,7 +409,14 @@ exports.setSchema = function (schema) {
   }
 
   function makeDocID(obj) {
-    return serialize(obj.type, obj.id);
+    var type = obj.type;
+
+    var typeInfo = keysToSchemas.get(type);
+    if (typeInfo) {
+      type = typeInfo.documentType;
+    }
+
+    return serialize(type, obj.id);
   }
 
   db.rel = {

--- a/test/test.js
+++ b/test/test.js
@@ -424,6 +424,92 @@ function tests(dbName, dbType) {
       });
     });
 
+    it('should find using a documentType if provided', function () {
+      db.setSchema([
+        {
+          singular: 'postSummary',
+          plural: 'postSummaries',
+          documentType: 'post'
+        }
+      ]);
+
+      return db.put({ data: { text: 'Oh no' } }, 'post_2_oh').then(function () {
+        return db.rel.find('postSummary', 'oh');
+      }).then(function (res) {
+        delete res.postSummaries[0].rev;
+        res.should.deep.equal({ postSummaries: [{
+          id: 'oh',
+          text: 'Oh no'
+        }] });
+      });
+    });
+
+    it('should save using a documentType if provided', function () {
+      db.setSchema([
+        {
+          singular: 'postSummary',
+          plural: 'postSummary',
+          documentType: 'post'
+        }
+      ]);
+
+      return db.rel.save('postSummary', { title: 'Hey', id: 'hello' }).then(function () {
+        return db.get('post_2_hello');
+      }).then(function (res) {
+        delete res._rev;
+        res.should.deep.equal({
+          _id: 'post_2_hello',
+          data: {
+            title: 'Hey'
+          }
+        });
+      });
+    });
+
+    it('should use the documentType for makeDocID', function () {
+      db.setSchema([
+        {
+          singular: 'post',
+          plural: 'posts'
+        },
+        {
+          singular: 'postSummary',
+          plural: 'postSummaries',
+          documentType: 'post'
+        }
+      ]);
+
+      db.rel.makeDocID({ type: 'postSummary', id: 'foo' }).should.equal('post_2_foo');
+    });
+
+    it('should use the default documentType for parseDocID, if present', function () {
+      db.setSchema([
+        {
+          singular: 'post',
+          plural: 'posts'
+        },
+        {
+          singular: 'postSummary',
+          plural: 'postSummaries',
+          documentType: 'post'
+        }
+      ]);
+
+      db.rel.parseDocID('post_2_bar').should.deep.equal({ type: 'post', id: 'bar' });
+    });
+
+    it('should use a type with a matching documentType for parseDocID, if no default', function () {
+      db.setSchema([
+        {
+          singular: 'postSummary',
+          plural: 'postSummaries',
+          documentType: 'post'
+        }
+      ]);
+
+      db.rel.parseDocID('post_2_bar').should.deep.equal({ type: 'postSummary', id: 'bar' });
+    });
+
     it('can delete', function () {
 
       db.setSchema([

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,18 @@ function tests(dbName, dbType) {
       currentId.should.equal(initialId);
     });
 
+    it('allows makeDocID for an unknown type', function () {
+      db.setSchema([]);
+
+      db.rel.makeDocID({ type: 'something', id: 'quux' }).should.equal('something_2_quux');
+    });
+
+    it('allows parseDocID for an unknown type', function () {
+      db.setSchema([]);
+
+      db.rel.parseDocID('something_2_bar').should.deep.equal({ type: 'something', id: 'bar' });
+    });
+
     it('should store blog posts', function () {
 
       db.setSchema([{


### PR DESCRIPTION
The motivation is to allow a simpler "view" over a single set of data. Reducing the number of declared relationships can make a noticeable difference when loading large volumes of records in ember-data, even if the relationships are async.