### PR TITLE
Keep the attachments attached

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,6 +116,7 @@ exports.setSchema = function (schema) {
     }
 
     if (obj.attachments) {
+      doc._attachments = obj.attachments;
       delete obj.attachments;
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -613,7 +613,12 @@ function tests(dbName, dbType) {
         id: 'with_attachment_info',
         title: "Files are cool",
         text: "In order to have nice blog posts we need to be able to add files",
-        attachments: {foo: attachment}
+        attachments: {
+          foo: {
+            content_type: 'text/plain',
+            data: attachment
+          }
+        }
       }).then(function () {
         return db.rel.find('post', 'with_attachment_info');
       }).then(function (res) {

--- a/test/test.js
+++ b/test/test.js
@@ -596,23 +596,30 @@ function tests(dbName, dbType) {
       });
     });
 
-    it('Removes attachment information on save', function () {
-
+    it('Does not remove attachment information on save', function () {
       db.setSchema([{
         singular: 'post',
         plural: 'posts'
       }]);
+      
+      var attachment;
+      if (process.browser) {
+        attachment = blobUtil.createBlob(['Is there life on Mars?']);
+      } else {
+        attachment = new Buffer('Is there life on Mars?');
+      }
 
       return db.rel.save('post', {
         id: 'with_attachment_info',
         title: "Files are cool",
         text: "In order to have nice blog posts we need to be able to add files",
-        attachments: {foo: "bar"}
+        attachments: {foo: attachment}
       }).then(function () {
         return db.rel.find('post', 'with_attachment_info');
       }).then(function (res) {
         var post = res.posts[0];
-        should.not.exist(post.attachments);
+        should.exist(post.attachments);
+        should.exist(post.attachments.foo);
       });
     });
 


### PR DESCRIPTION
This is basically a duplicate of #20, with tests adjusted for expected (sane) behavior.

There should probably be more tests. The one right now only checks that the attachment is saved along with the document on creation. Additionally, we want to ensure that the attachments are not lost when the document is updated, unless we explicitly delete some/all of them.