### PR TITLE
(#36) - fix attachments API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -366,6 +366,7 @@ exports.setSchema = function (schema) {
   }
 
   function getAttachment(type, id, attachmentId, options) {
+    options = options || {};
     return Promise.resolve().then(function () {
       return db.getAttachment(serialize(type, id), attachmentId, options);
     });


### PR DESCRIPTION
Looks like a mistake that snuck in when PouchDB did some
housekeeping and removed the automatic undefined -> {}
conversion.