### PR TITLE
Added db.rel.query(type, func, options) and db.rel.find(type, options)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ API
 * [`db.rel.find(type)`](#dbrelfindtype)
 * [`db.rel.find(type, id)`](#dbrelfindtype-id)
 * [`db.rel.find(type, ids)`](#dbrelfindtype-ids)
-* [`db.rel.find(type, null, options)`](#dbrelfindtype-null-options)
+* [`db.rel.find(type, options)`](#dbrelfindtype-options)
 * [`db.rel.del(type, object)`](#dbreldeltype-object)
 * [`db.rel.putAttachment(type, object, attachmentId, attachment, attachmentType)`](#dbrelputattachmenttype-object-attachmentid-attachment-attachmenttype)
 * [`db.rel.getAttachment(type, id, attachmentId)`](#dbrelgetattachmenttype-id-attachmentid)
@@ -288,12 +288,12 @@ If an `id` isn't found, it's simply not returned. Notice that above, there is no
 
 `find` results are always returned ordered by id. The order of your `ids` array will not necessarily be reflected in the returned array of objects.
 
-### db.rel.find(type, null, options)
+### db.rel.find(type, options)
 
-Find all objects with a given type and specified options as defined for [PouchDB batch fetch](http://pouchdb.com/api.html#batch_fetch). Returns a Promise.
+Find all objects with a given type and limit the results via the passed in options.  Returns a Promise.
 
 ```js
-db.rel.find('post', null, {startkey: db.rel.makeDocID({type: 'post', id: 1}), limit: 2});
+db.rel.find('post',{startkey: 1, limit: 2});
 ```
 
 Result:
@@ -316,7 +316,10 @@ Result:
   ]
 }
 ```
-The `include_docs`, `conflicts`, and `attachments` options are not supported.
+The following options based on the options for [PouchDB batch fetch](http://pouchdb.com/api.html#batch_fetch) are available:
+* `startkey` & `endkey`:  Get documents with IDs in a certain range (inclusive/inclusive).
+* `limit`: Maximum number of documents to return.
+* `skip`: Number of docs to skip before returning (warning: poor performance on IndexedDB/LevelDB!).
 
 ### db.rel.del(type, object)
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ API
 * [`db.rel.find(type)`](#dbrelfindtype)
 * [`db.rel.find(type, id)`](#dbrelfindtype-id)
 * [`db.rel.find(type, ids)`](#dbrelfindtype-ids)
+* [`db.rel.find(type, null, options)`](#dbrelfindtype-null-options)
 * [`db.rel.del(type, object)`](#dbreldeltype-object)
 * [`db.rel.putAttachment(type, object, attachmentId, attachment, attachmentType)`](#dbrelputattachmenttype-object-attachmentid-attachment-attachmenttype)
 * [`db.rel.getAttachment(type, id, attachmentId)`](#dbrelgetattachmenttype-id-attachmentid)
@@ -286,6 +287,36 @@ Result:
 If an `id` isn't found, it's simply not returned. Notice that above, there is no object with an `id` of `3`. 
 
 `find` results are always returned ordered by id. The order of your `ids` array will not necessarily be reflected in the returned array of objects.
+
+### db.rel.find(type, null, options)
+
+Find all objects with a given type and specified options as defined for [PouchDB batch fetch](http://pouchdb.com/api.html#batch_fetch). Returns a Promise.
+
+```js
+db.rel.find('post', null, {startkey:1, limit:2});
+```
+
+Result:
+
+```js
+{
+  "posts": [
+    {
+      "title": "Rails is Unagi",
+      "text": "Delicious unagi. Mmmmmm.",
+      "id": 1,
+      "rev": "1-0ae315ee597b22cc4b1acf9e0edc35ba"
+    },  
+    {
+      "title": "Maybe Rails is more like a sushi buffet",
+      "text": "Heresy!",
+      "id": 2,
+      "rev": "1-6d8ac6d86d01b91cfbe2f53e0c81bb86"
+    }
+  ]
+}
+```
+The `include_docs`, `conflicts` and `attachments` options are not supported.
 
 ### db.rel.del(type, object)
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ If an `id` isn't found, it's simply not returned. Notice that above, there is no
 Find all objects with a given type and specified options as defined for [PouchDB batch fetch](http://pouchdb.com/api.html#batch_fetch). Returns a Promise.
 
 ```js
-db.rel.find('post', null, {startkey:1, limit:2});
+db.rel.find('post', null, {startkey: db.rel.makeDocID({type: 'post', id: 1}), limit: 2});
 ```
 
 Result:
@@ -316,7 +316,7 @@ Result:
   ]
 }
 ```
-The `include_docs`, `conflicts` and `attachments` options are not supported.
+The `include_docs`, `conflicts`, and `attachments` options are not supported.
 
 ### db.rel.del(type, object)
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ API
 * [`db.rel.find(type, id)`](#dbrelfindtype-id)
 * [`db.rel.find(type, ids)`](#dbrelfindtype-ids)
 * [`db.rel.find(type, options)`](#dbrelfindtype-options)
+* [`db.rel.query(type, func, options)`](#dbrelquerytype-func-options)
 * [`db.rel.del(type, object)`](#dbreldeltype-object)
 * [`db.rel.putAttachment(type, object, attachmentId, attachment, attachmentType)`](#dbrelputattachmenttype-object-attachmentid-attachment-attachmenttype)
 * [`db.rel.getAttachment(type, id, attachmentId)`](#dbrelgetattachmenttype-id-attachmentid)
@@ -320,6 +321,47 @@ The following options based on the options for [PouchDB batch fetch](http://pouc
 * `startkey` & `endkey`:  Get documents with IDs in a certain range (inclusive/inclusive).
 * `limit`: Maximum number of documents to return.
 * `skip`: Number of docs to skip before returning (warning: poor performance on IndexedDB/LevelDB!).
+
+### db.rel.query(type, func, options)
+
+Invoke a map/reduce function to find results for the given type and limit the results via the passed in options.  Returns a Promise.
+
+```js
+db.rel.query('post','index/by_text',{limit: 2});
+```
+
+Result:
+
+```js
+{
+  "posts": [
+    {
+      "title": "Rails is Unagi",
+      "text": "Delicious unagi. Mmmmmm.",
+      "id": 1,
+      "rev": "1-0ae315ee597b22cc4b1acf9e0edc35ba"
+    },  
+    {
+      "title": "Maybe Rails is more like a sushi buffet",
+      "text": "Heresy!",
+      "id": 2,
+      "rev": "1-6d8ac6d86d01b91cfbe2f53e0c81bb86"
+    }
+  ]
+}
+```
+The following options based on the options for [PouchDB query database](http://pouchdb.com/api.html#query_database) are available:
+* `func`: Map/reduce function, which can be one of the following:
+ * A full CouchDB-style map/reduce view: `{map : ..., reduce: ...}`.
+ * A map function by itself (no reduce).
+ * The name of a view in an existing design document (e.g. 'mydesigndoc/myview', or 'myview' as a shorthand for 'myview/myview').
+* `options.startkey` & `options.endkey`:  Get documents with IDs in a certain range (inclusive/inclusive).
+* `options.key`:  Get objects that match this ID as returned from the map/reduce function.
+* `option.keys`:  Get objects that match this array of IDs as returned from the map/reduce function. Results will be ordered by this array of IDs.
+* `option.limit`: Maximum number of documents to return.
+* `option.skip`: Number of docs to skip before returning (warning: poor performance on IndexedDB/LevelDB!).
+
+`query` results are returned as ordered by the ids returned from the map/reduce function unless the keys option is passed in.
 
 ### db.rel.del(type, object)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -207,25 +207,39 @@ exports.setSchema = function (schema) {
     });
   }
 
-  function _find(type, idOrIds, foundObjects, options) {
+  function _find(type, idOrIds, foundObjects) {
     var typeInfo = getTypeInfo(type);
 
-    var opts = options || {};        
-    opts.include_docs = true;    
+    var opts = {
+      include_docs: true
+    };
 
     if (typeof idOrIds === 'undefined' || idOrIds === null) {
       // find everything
-      if (typeof opts.startkey  === 'undefined' || opts.startkey === null) {
-        opts.startkey = serialize(typeInfo.documentType);
-      }
-      if (typeof opts.endkey  === 'undefined' || opts.endkey === null) {
-        opts.endkey = serialize(typeInfo.documentType, {});
-      }
+      opts.startkey = serialize(typeInfo.documentType);
+      opts.endkey = serialize(typeInfo.documentType, {});
     } else if (Array.isArray(idOrIds)) {
       // find multiple by ids
       opts.keys = idOrIds.map(function (id) {
         return serialize(typeInfo.documentType, id);
       });
+    } else if (typeof idOrIds === 'object') {
+      if (typeof idOrIds.startkey  === 'undefined' || idOrIds.startkey === null) {
+        opts.startkey = serialize(typeInfo.documentType);
+      } else {
+        opts.startkey = serialize(typeInfo.documentType, idOrIds.startkey);
+      }
+      if (typeof idOrIds.endkey  === 'undefined' || idOrIds.endkey === null) {
+        opts.endkey = serialize(typeInfo.documentType, {});
+      } else {
+        opts.endkey = serialize(typeInfo.documentType, idOrIds.endkey);
+      }
+      if (typeof idOrIds.limit !== 'undefined' && idOrIds.limit !== null) {
+        opts.limit = idOrIds.limit;
+      }
+      if (typeof idOrIds.skip !== 'undefined' && idOrIds.skip !== null) {
+        opts.skip = idOrIds.skip;
+      }
     } else {
     // find by single id
       opts.key = serialize(typeInfo.documentType, idOrIds);
@@ -381,9 +395,9 @@ exports.setSchema = function (schema) {
     });
   }
 
-  function find(type, idOrIds, options) {
+  function find(type, idOrIds) {
     return Promise.resolve().then(function () {
-      return _find(type, idOrIds, new collections.Map(), options);
+      return _find(type, idOrIds, new collections.Map());
     });
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -234,12 +234,7 @@ exports.setSchema = function (schema) {
       } else {
         opts.endkey = serialize(typeInfo.documentType, idOrIds.endkey);
       }
-      if (typeof idOrIds.limit !== 'undefined' && idOrIds.limit !== null) {
-        opts.limit = idOrIds.limit;
-      }
-      if (typeof idOrIds.skip !== 'undefined' && idOrIds.skip !== null) {
-        opts.skip = idOrIds.skip;
-      }
+      opts = _addAllowedOptions(idOrIds, ['limit', 'skip'], opts);
     } else {
     // find by single id
       opts.key = serialize(typeInfo.documentType, idOrIds);
@@ -250,106 +245,146 @@ exports.setSchema = function (schema) {
     }
 
     return db.allDocs(opts).then(function (pouchRes) {
-      var tasks = pouchRes.rows.filter(function (row) {
-        return row.doc && !row.value.deleted;
-      }).map(function (row) {
-        var obj = fromRawDoc(row.doc);
-
-        foundObjects.get(type).set(JSON.stringify(obj.id), obj);
-
-        // fetch all relations
-        var subTasks = [];
-        Object.keys(typeInfo.relations || {}).forEach(function (field) {
-          var relationDef = typeInfo.relations[field];
-          var relationType = Object.keys(relationDef)[0];
-          var relatedType = relationDef[relationType];
-          if (typeof relatedType !== 'string') {
-            var relationOptions = relatedType.options;
-            if (relationOptions && relationOptions.async) {
-              return;
-            }
-            relatedType = relatedType.type;
-          }
-          if (relationType === 'belongsTo') {
-            var relatedId = obj[field];
-            if (typeof relatedId !== 'undefined') {
-              subTasks.push(Promise.resolve().then(function () {
-
-                // short-circuit if it's already in the foundObjects
-                // else we could get caught in an infinite loop
-                if (foundObjects.has(relatedType) &&
-                    foundObjects.get(relatedType).has(JSON.stringify(relatedId))) {
-                  return;
-                }
-
-                // signal that we need to fetch it
-                return {
-                  relatedType: relatedType,
-                  relatedIds: [relatedId]
-                };
-              }));
-            }
-          } else { // hasMany
-            var relatedIds = extend(true, [], obj[field]);
-            if (typeof relatedIds !== 'undefined' && relatedIds.length) {
-              subTasks.push(Promise.resolve().then(function () {
-
-                // filter out all ids that are already in the foundObjects
-                for (var i = relatedIds.length - 1; i >= 0; i--) {
-                  var relatedId = relatedIds[i];
-                  if (foundObjects.has(relatedType) &&
-                      foundObjects.get(relatedType).has(JSON.stringify(relatedId))) {
-                    delete relatedIds[i];
-                  }
-                }
-                relatedIds = relatedIds.filter(function (relatedId) {
-                  return typeof relatedId !== 'undefined';
-                });
-
-                // just return the ids and the types. We'll find them all
-                // in a single bulk operation in order to minimize HTTP requests
-                if (relatedIds.length) {
-                  return {
-                    relatedType: relatedType,
-                    relatedIds: relatedIds
-                  };
-                }
-              }));
-            }
-          }
-        });
-        return Promise.all(subTasks);
-      });
-      return Promise.all(tasks);
+      return _resolveResults(pouchRes, foundObjects, type, typeInfo);
     }).then(function (listsOfFetchTasks) {
-      // fetch in as few http requests as possible
-      var typesToIds = {};
-      listsOfFetchTasks.forEach(function (fetchTasks) {
-        fetchTasks.forEach(function (fetchTask) {
-          if (!fetchTask) {
+      return _fetchRelationships(listsOfFetchTasks, foundObjects, true);
+    });
+  }
+  
+  function _addAllowedOptions(passedOptions, allowedOptions, currentOptions) {
+    allowedOptions.forEach(function (option) {
+      if (typeof passedOptions[option] !== 'undefined' && passedOptions.skip !== null) {
+        currentOptions[option] = passedOptions[option];
+      }
+    });
+    return currentOptions;
+  }
+    
+  function _resolveResults(pouchRes, foundObjects, type, typeInfo) {
+    var tasks = pouchRes.rows.filter(function (row) {
+      return row.doc && (!row.value || !row.value.deleted);
+    }).map(function (row) {
+      var obj = fromRawDoc(row.doc);
+
+      foundObjects.get(type).set(JSON.stringify(obj.id), obj);
+
+      // fetch all relations
+      var subTasks = [];
+      Object.keys(typeInfo.relations || {}).forEach(function (field) {
+        var relationDef = typeInfo.relations[field];
+        var relationType = Object.keys(relationDef)[0];
+        var relatedType = relationDef[relationType];
+        if (typeof relatedType !== 'string') {
+          var relationOptions = relatedType.options;
+          if (relationOptions && relationOptions.async) {
             return;
           }
-          typesToIds[fetchTask.relatedType] =
-            (typesToIds[fetchTask.relatedType] || []).concat(fetchTask.relatedIds);
-        });
-      });
+          relatedType = relatedType.type;
+        }
+        if (relationType === 'belongsTo') {
+          var relatedId = obj[field];
+          if (typeof relatedId !== 'undefined') {
+            subTasks.push(Promise.resolve().then(function () {
 
-      return utils.series(Object.keys(typesToIds).map(function (relatedType) {
-        var relatedIds = uniq(typesToIds[relatedType]);
-        return function () {return _find(relatedType, relatedIds, foundObjects); };
-      })).then(function () {
-        var res = {};
-        foundObjects.forEach(function (found, type) {
-          var typeInfo = getTypeInfo(type);
-          var list = res[typeInfo.plural] = [];
-          found.forEach(function (obj) {
-            list.push(obj);
-          });
-          list.sort(lexCompare);
-        });
-        return res;
+              // short-circuit if it's already in the foundObjects
+              // else we could get caught in an infinite loop
+              if (foundObjects.has(relatedType) &&
+                  foundObjects.get(relatedType).has(JSON.stringify(relatedId))) {
+                return;
+              }
+
+              // signal that we need to fetch it
+              return {
+                relatedType: relatedType,
+                relatedIds: [relatedId]
+              };
+            }));
+          }
+        } else { // hasMany
+          var relatedIds = extend(true, [], obj[field]);
+          if (typeof relatedIds !== 'undefined' && relatedIds.length) {
+            subTasks.push(Promise.resolve().then(function () {
+
+              // filter out all ids that are already in the foundObjects
+              for (var i = relatedIds.length - 1; i >= 0; i--) {
+                var relatedId = relatedIds[i];
+                if (foundObjects.has(relatedType) &&
+                    foundObjects.get(relatedType).has(JSON.stringify(relatedId))) {
+                  delete relatedIds[i];
+                }
+              }
+              relatedIds = relatedIds.filter(function (relatedId) {
+                return typeof relatedId !== 'undefined';
+              });
+
+              // just return the ids and the types. We'll find them all
+              // in a single bulk operation in order to minimize HTTP requests
+              if (relatedIds.length) {
+                return {
+                  relatedType: relatedType,
+                  relatedIds: relatedIds
+                };
+              }
+            }));
+          }
+        }
+      });
+      return Promise.all(subTasks);
+    });
+    return Promise.all(tasks);
+  }
+
+  function _fetchRelationships(listsOfFetchTasks, foundObjects, shouldSort) {
+    // fetch in as few http requests as possible
+    var typesToIds = {};
+    listsOfFetchTasks.forEach(function (fetchTasks) {
+      fetchTasks.forEach(function (fetchTask) {
+        if (!fetchTask) {
+          return;
+        }
+        typesToIds[fetchTask.relatedType] =
+          (typesToIds[fetchTask.relatedType] || []).concat(fetchTask.relatedIds);
       });
     });
+
+    return utils.series(Object.keys(typesToIds).map(function (relatedType) {
+      var relatedIds = uniq(typesToIds[relatedType]);
+      return function () {return _find(relatedType, relatedIds, foundObjects); };
+    })).then(function () {
+      var res = {};
+      foundObjects.forEach(function (found, type) {
+        var typeInfo = getTypeInfo(type);
+        var list = res[typeInfo.plural] = [];
+        found.forEach(function (obj) {
+          list.push(obj);
+        });
+        if (shouldSort) {
+          list.sort(lexCompare);
+        }
+      });
+      return res;
+    });
+  }
+  
+  function _query(type, fun, options) {
+    var foundObjects = new collections.Map();
+    foundObjects.set(type, new collections.Map());
+    var typeInfo = getTypeInfo(type);
+    var opts = _addAllowedOptions(options, [
+      'startkey',
+      'endkey',
+      'key',
+      'keys',
+      'limit', 
+      'skip'
+    ], {});
+    opts.include_docs = true;
+    return db.query(fun, opts).then(function (pouchRes) {
+      return _resolveResults(pouchRes, foundObjects, type, typeInfo);
+    }).then(function (listsOfFetchTasks) {
+      return _fetchRelationships(listsOfFetchTasks, foundObjects, false);
+    });
+    
   }
 
   function putAttachment(type, obj, attachmentId, attachment, attachmentType) {
@@ -406,6 +441,12 @@ exports.setSchema = function (schema) {
       return _del(type, obj);
     });
   }
+  
+  function query(type, fun, options) {
+    return Promise.resolve().then(function () {
+      return _query(type, fun, options);
+    });
+  }
 
   function parseDocID(str) {
     var idx = str.indexOf('_');
@@ -446,7 +487,8 @@ exports.setSchema = function (schema) {
     putAttachment: putAttachment,
     removeAttachment: removeAttachment,
     parseDocID: parseDocID,
-    makeDocID: makeDocID
+    makeDocID: makeDocID,
+    query: query
   };
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -207,17 +207,20 @@ exports.setSchema = function (schema) {
     });
   }
 
-  function _find(type, idOrIds, foundObjects) {
+  function _find(type, idOrIds, foundObjects, options) {
     var typeInfo = getTypeInfo(type);
 
-    var opts = {
-      include_docs: true
-    };
+    var opts = options || {};        
+    opts.include_docs = true;    
 
     if (typeof idOrIds === 'undefined' || idOrIds === null) {
       // find everything
-      opts.startkey = serialize(typeInfo.documentType);
-      opts.endkey = serialize(typeInfo.documentType, {});
+      if (typeof opts.startkey  === 'undefined' || opts.startkey === null) {
+        opts.startkey = serialize(typeInfo.documentType);
+      }
+      if (typeof opts.endkey  === 'undefined' || opts.endkey === null) {
+        opts.endkey = serialize(typeInfo.documentType, {});
+      }
     } else if (Array.isArray(idOrIds)) {
       // find multiple by ids
       opts.keys = idOrIds.map(function (id) {
@@ -378,9 +381,9 @@ exports.setSchema = function (schema) {
     });
   }
 
-  function find(type, idOrIds) {
+  function find(type, idOrIds, options) {
     return Promise.resolve().then(function () {
-      return _find(type, idOrIds, new collections.Map());
+      return _find(type, idOrIds, new collections.Map(), options);
     });
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1908,7 +1908,7 @@ function tests(dbName, dbType) {
           id: 2
         });
       }).then(function () {
-        return db.rel.find('post', null, {limit: 1});
+        return db.rel.find('post', {limit: 1});
       }).then(function (res) {
         res.posts.forEach(function (post) {
           post.rev.should.be.a('string');
@@ -1946,8 +1946,8 @@ function tests(dbName, dbType) {
         });
       }).then(function () {
         
-        return db.rel.find('post', null, {
-          startkey: db.rel.makeDocID({ type: 'post', id: 2 }), 
+        return db.rel.find('post', {
+          startkey: 2, 
           limit: 1
         });
       }).then(function (res) {
@@ -1986,8 +1986,8 @@ function tests(dbName, dbType) {
           id: 2
         });
       }).then(function () {
-        return db.rel.find('post', null, {
-          endkey: db.rel.makeDocID({ type: 'post', id: 1 }),
+        return db.rel.find('post', {
+          endkey: 1,
         });
       }).then(function (res) {
         res.posts.forEach(function (post) {
@@ -2006,4 +2006,46 @@ function tests(dbName, dbType) {
       });
     });
   });
+  
+  it('should pass along options, including kip', function () {
+
+      db.setSchema([{
+        singular: 'post',
+        plural: 'posts'
+      }]);
+
+
+      return db.rel.save('post', {
+        title: 'Rails is Omakase',
+        text: 'There are a lot of ala carte blah blah blah',
+        id: 1
+      }).then(function () {
+        return db.rel.save('post', {
+          title: 'Rails is Unagi',
+          text: 'Declicious unagi',
+          id: 2
+        });
+      }).then(function () {
+        
+        return db.rel.find('post', {
+          skip: 1, 
+          limit: 1
+        });
+      }).then(function (res) {
+        res.posts.forEach(function (post) {
+          post.rev.should.be.a('string');
+          delete post.rev;
+        });
+        res.should.deep.equal({
+          posts: [
+            {
+              title: 'Rails is Unagi',
+              text: 'Declicious unagi',
+              id: 2
+            }
+          ]
+        });
+      });
+    }); 
+  
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1888,5 +1888,122 @@ function tests(dbName, dbType) {
         ]);
       });
     });
+    
+    it('should pass along options', function () {
+
+      db.setSchema([{
+        singular: 'post',
+        plural: 'posts'
+      }]);
+
+
+      return db.rel.save('post', {
+        title: 'Rails is Omakase',
+        text: 'There are a lot of ala carte blah blah blah',
+        id: 1
+      }).then(function () {
+        return db.rel.save('post', {
+          title: 'Rails is Unagi',
+          text: 'Declicious unagi',
+          id: 2
+        });
+      }).then(function () {
+        return db.rel.find('post', null, {limit: 1});
+      }).then(function (res) {
+        res.posts.forEach(function (post) {
+          post.rev.should.be.a('string');
+          delete post.rev;
+        });
+        res.should.deep.equal({
+          posts: [
+            {
+              title: 'Rails is Omakase',
+              text: 'There are a lot of ala carte blah blah blah',
+              id: 1
+            }
+          ]
+        });
+      });
+    });
+    
+    it('should pass along options, including startkey', function () {
+
+      db.setSchema([{
+        singular: 'post',
+        plural: 'posts'
+      }]);
+
+
+      return db.rel.save('post', {
+        title: 'Rails is Omakase',
+        text: 'There are a lot of ala carte blah blah blah',
+        id: 1
+      }).then(function () {
+        return db.rel.save('post', {
+          title: 'Rails is Unagi',
+          text: 'Declicious unagi',
+          id: 2
+        });
+      }).then(function () {
+        
+        return db.rel.find('post', null, {
+          startkey: db.rel.makeDocID({ type: 'post', id: 2 }), 
+          limit: 1
+        });
+      }).then(function (res) {
+        res.posts.forEach(function (post) {
+          post.rev.should.be.a('string');
+          delete post.rev;
+        });
+        res.should.deep.equal({
+          posts: [
+            {
+              title: 'Rails is Unagi',
+              text: 'Declicious unagi',
+              id: 2
+            }
+          ]
+        });
+      });
+    }); 
+
+    it('should pass along options, including endkey', function () {
+
+      db.setSchema([{
+        singular: 'post',
+        plural: 'posts'
+      }]);
+
+
+      return db.rel.save('post', {
+        title: 'Rails is Omakase',
+        text: 'There are a lot of ala carte blah blah blah',
+        id: 1
+      }).then(function () {
+        return db.rel.save('post', {
+          title: 'Rails is Unagi',
+          text: 'Declicious unagi',
+          id: 2
+        });
+      }).then(function () {
+        return db.rel.find('post', null, {
+          endkey: db.rel.makeDocID({ type: 'post', id: 1 }),
+        });
+      }).then(function (res) {
+        res.posts.forEach(function (post) {
+          post.rev.should.be.a('string');
+          delete post.rev;
+        });
+        res.should.deep.equal({
+          posts: [
+            {
+              title: 'Rails is Omakase',
+              text: 'There are a lot of ala carte blah blah blah',
+              id: 1
+            }
+          ]
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
Right now there is no way to pass along options to PouchDB.allDocs from db.rel.find. This PR adds the ability to pass along options to allDocs.  I need this for paging, but I guess there may be other uses as well.