### PR TITLE
Added db.rel.query

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ API
 * [`db.rel.find(type, id)`](#dbrelfindtype-id)
 * [`db.rel.find(type, ids)`](#dbrelfindtype-ids)
 * [`db.rel.find(type, options)`](#dbrelfindtype-options)
+* [`db.rel.query(type, func, options)`](#dbrelquerytype-func-options)
 * [`db.rel.del(type, object)`](#dbreldeltype-object)
 * [`db.rel.putAttachment(type, object, attachmentId, attachment, attachmentType)`](#dbrelputattachmenttype-object-attachmentid-attachment-attachmenttype)
 * [`db.rel.getAttachment(type, id, attachmentId)`](#dbrelgetattachmenttype-id-attachmentid)
@@ -320,6 +321,47 @@ The following options based on the options for [PouchDB batch fetch](http://pouc
 * `startkey` & `endkey`:  Get documents with IDs in a certain range (inclusive/inclusive).
 * `limit`: Maximum number of documents to return.
 * `skip`: Number of docs to skip before returning (warning: poor performance on IndexedDB/LevelDB!).
+
+### db.rel.query(type, func, options)
+
+Invoke a map/reduce function to find results for the given type and limit the results via the passed in options.  Returns a Promise.
+
+```js
+db.rel.query('post','index/by_text',{limit: 2});
+```
+
+Result:
+
+```js
+{
+  "posts": [
+    {
+      "title": "Rails is Unagi",
+      "text": "Delicious unagi. Mmmmmm.",
+      "id": 1,
+      "rev": "1-0ae315ee597b22cc4b1acf9e0edc35ba"
+    },  
+    {
+      "title": "Maybe Rails is more like a sushi buffet",
+      "text": "Heresy!",
+      "id": 2,
+      "rev": "1-6d8ac6d86d01b91cfbe2f53e0c81bb86"
+    }
+  ]
+}
+```
+The following options based on the options for [PouchDB query database](http://pouchdb.com/api.html#query_database) are available:
+* `func`: Map/reduce function, which can be one of the following:
+ * A full CouchDB-style map/reduce view: `{map : ..., reduce: ...}`.
+ * A map function by itself (no reduce).
+ * The name of a view in an existing design document (e.g. 'mydesigndoc/myview', or 'myview' as a shorthand for 'myview/myview').
+* `options.startkey` & `options.endkey`:  Get documents with IDs in a certain range (inclusive/inclusive).
+* `options.key`:  Get objects that match this ID as returned from the map/reduce function.
+* `option.keys`:  Get objects that match this array of IDs as returned from the map/reduce function. Results will be ordered by this array of IDs.
+* `option.limit`: Maximum number of documents to return.
+* `option.skip`: Number of docs to skip before returning (warning: poor performance on IndexedDB/LevelDB!).
+
+`query` results are returned as ordered by the ids returned from the map/reduce function unless the keys option is passed in.
 
 ### db.rel.del(type, object)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -234,12 +234,7 @@ exports.setSchema = function (schema) {
       } else {
         opts.endkey = serialize(typeInfo.documentType, idOrIds.endkey);
       }
-      if (typeof idOrIds.limit !== 'undefined' && idOrIds.limit !== null) {
-        opts.limit = idOrIds.limit;
-      }
-      if (typeof idOrIds.skip !== 'undefined' && idOrIds.skip !== null) {
-        opts.skip = idOrIds.skip;
-      }
+      opts = _addAllowedOptions(idOrIds, ['limit', 'skip'], opts);
     } else {
     // find by single id
       opts.key = serialize(typeInfo.documentType, idOrIds);
@@ -250,106 +245,146 @@ exports.setSchema = function (schema) {
     }
 
     return db.allDocs(opts).then(function (pouchRes) {
-      var tasks = pouchRes.rows.filter(function (row) {
-        return row.doc && !row.value.deleted;
-      }).map(function (row) {
-        var obj = fromRawDoc(row.doc);
-
-        foundObjects.get(type).set(JSON.stringify(obj.id), obj);
-
-        // fetch all relations
-        var subTasks = [];
-        Object.keys(typeInfo.relations || {}).forEach(function (field) {
-          var relationDef = typeInfo.relations[field];
-          var relationType = Object.keys(relationDef)[0];
-          var relatedType = relationDef[relationType];
-          if (typeof relatedType !== 'string') {
-            var relationOptions = relatedType.options;
-            if (relationOptions && relationOptions.async) {
-              return;
-            }
-            relatedType = relatedType.type;
-          }
-          if (relationType === 'belongsTo') {
-            var relatedId = obj[field];
-            if (typeof relatedId !== 'undefined') {
-              subTasks.push(Promise.resolve().then(function () {
-
-                // short-circuit if it's already in the foundObjects
-                // else we could get caught in an infinite loop
-                if (foundObjects.has(relatedType) &&
-                    foundObjects.get(relatedType).has(JSON.stringify(relatedId))) {
-                  return;
-                }
-
-                // signal that we need to fetch it
-                return {
-                  relatedType: relatedType,
-                  relatedIds: [relatedId]
-                };
-              }));
-            }
-          } else { // hasMany
-            var relatedIds = extend(true, [], obj[field]);
-            if (typeof relatedIds !== 'undefined' && relatedIds.length) {
-              subTasks.push(Promise.resolve().then(function () {
-
-                // filter out all ids that are already in the foundObjects
-                for (var i = relatedIds.length - 1; i >= 0; i--) {
-                  var relatedId = relatedIds[i];
-                  if (foundObjects.has(relatedType) &&
-                      foundObjects.get(relatedType).has(JSON.stringify(relatedId))) {
-                    delete relatedIds[i];
-                  }
-                }
-                relatedIds = relatedIds.filter(function (relatedId) {
-                  return typeof relatedId !== 'undefined';
-                });
-
-                // just return the ids and the types. We'll find them all
-                // in a single bulk operation in order to minimize HTTP requests
-                if (relatedIds.length) {
-                  return {
-                    relatedType: relatedType,
-                    relatedIds: relatedIds
-                  };
-                }
-              }));
-            }
-          }
-        });
-        return Promise.all(subTasks);
-      });
-      return Promise.all(tasks);
+      return _resolveResults(pouchRes, foundObjects, type, typeInfo);
     }).then(function (listsOfFetchTasks) {
-      // fetch in as few http requests as possible
-      var typesToIds = {};
-      listsOfFetchTasks.forEach(function (fetchTasks) {
-        fetchTasks.forEach(function (fetchTask) {
-          if (!fetchTask) {
+      return _fetchRelationships(listsOfFetchTasks, foundObjects, true);
+    });
+  }
+  
+  function _addAllowedOptions(passedOptions, allowedOptions, currentOptions) {
+    allowedOptions.forEach(function (option) {
+      if (typeof passedOptions[option] !== 'undefined' && passedOptions.skip !== null) {
+        currentOptions[option] = passedOptions[option];
+      }
+    });
+    return currentOptions;
+  }
+    
+  function _resolveResults(pouchRes, foundObjects, type, typeInfo) {
+    var tasks = pouchRes.rows.filter(function (row) {
+      return row.doc && (!row.value || !row.value.deleted);
+    }).map(function (row) {
+      var obj = fromRawDoc(row.doc);
+
+      foundObjects.get(type).set(JSON.stringify(obj.id), obj);
+
+      // fetch all relations
+      var subTasks = [];
+      Object.keys(typeInfo.relations || {}).forEach(function (field) {
+        var relationDef = typeInfo.relations[field];
+        var relationType = Object.keys(relationDef)[0];
+        var relatedType = relationDef[relationType];
+        if (typeof relatedType !== 'string') {
+          var relationOptions = relatedType.options;
+          if (relationOptions && relationOptions.async) {
             return;
           }
-          typesToIds[fetchTask.relatedType] =
-            (typesToIds[fetchTask.relatedType] || []).concat(fetchTask.relatedIds);
-        });
-      });
+          relatedType = relatedType.type;
+        }
+        if (relationType === 'belongsTo') {
+          var relatedId = obj[field];
+          if (typeof relatedId !== 'undefined') {
+            subTasks.push(Promise.resolve().then(function () {
 
-      return utils.series(Object.keys(typesToIds).map(function (relatedType) {
-        var relatedIds = uniq(typesToIds[relatedType]);
-        return function () {return _find(relatedType, relatedIds, foundObjects); };
-      })).then(function () {
-        var res = {};
-        foundObjects.forEach(function (found, type) {
-          var typeInfo = getTypeInfo(type);
-          var list = res[typeInfo.plural] = [];
-          found.forEach(function (obj) {
-            list.push(obj);
-          });
-          list.sort(lexCompare);
-        });
-        return res;
+              // short-circuit if it's already in the foundObjects
+              // else we could get caught in an infinite loop
+              if (foundObjects.has(relatedType) &&
+                  foundObjects.get(relatedType).has(JSON.stringify(relatedId))) {
+                return;
+              }
+
+              // signal that we need to fetch it
+              return {
+                relatedType: relatedType,
+                relatedIds: [relatedId]
+              };
+            }));
+          }
+        } else { // hasMany
+          var relatedIds = extend(true, [], obj[field]);
+          if (typeof relatedIds !== 'undefined' && relatedIds.length) {
+            subTasks.push(Promise.resolve().then(function () {
+
+              // filter out all ids that are already in the foundObjects
+              for (var i = relatedIds.length - 1; i >= 0; i--) {
+                var relatedId = relatedIds[i];
+                if (foundObjects.has(relatedType) &&
+                    foundObjects.get(relatedType).has(JSON.stringify(relatedId))) {
+                  delete relatedIds[i];
+                }
+              }
+              relatedIds = relatedIds.filter(function (relatedId) {
+                return typeof relatedId !== 'undefined';
+              });
+
+              // just return the ids and the types. We'll find them all
+              // in a single bulk operation in order to minimize HTTP requests
+              if (relatedIds.length) {
+                return {
+                  relatedType: relatedType,
+                  relatedIds: relatedIds
+                };
+              }
+            }));
+          }
+        }
+      });
+      return Promise.all(subTasks);
+    });
+    return Promise.all(tasks);
+  }
+
+  function _fetchRelationships(listsOfFetchTasks, foundObjects, shouldSort) {
+    // fetch in as few http requests as possible
+    var typesToIds = {};
+    listsOfFetchTasks.forEach(function (fetchTasks) {
+      fetchTasks.forEach(function (fetchTask) {
+        if (!fetchTask) {
+          return;
+        }
+        typesToIds[fetchTask.relatedType] =
+          (typesToIds[fetchTask.relatedType] || []).concat(fetchTask.relatedIds);
       });
     });
+
+    return utils.series(Object.keys(typesToIds).map(function (relatedType) {
+      var relatedIds = uniq(typesToIds[relatedType]);
+      return function () {return _find(relatedType, relatedIds, foundObjects); };
+    })).then(function () {
+      var res = {};
+      foundObjects.forEach(function (found, type) {
+        var typeInfo = getTypeInfo(type);
+        var list = res[typeInfo.plural] = [];
+        found.forEach(function (obj) {
+          list.push(obj);
+        });
+        if (shouldSort) {
+          list.sort(lexCompare);
+        }
+      });
+      return res;
+    });
+  }
+  
+  function _query(type, fun, options) {
+    var foundObjects = new collections.Map();
+    foundObjects.set(type, new collections.Map());
+    var typeInfo = getTypeInfo(type);
+    var opts = _addAllowedOptions(options, [
+      'startkey',
+      'endkey',
+      'key',
+      'keys',
+      'limit', 
+      'skip'
+    ], {});
+    opts.include_docs = true;
+    return db.query(fun, opts).then(function (pouchRes) {
+      return _resolveResults(pouchRes, foundObjects, type, typeInfo);
+    }).then(function (listsOfFetchTasks) {
+      return _fetchRelationships(listsOfFetchTasks, foundObjects, false);
+    });
+    
   }
 
   function putAttachment(type, obj, attachmentId, attachment, attachmentType) {
@@ -406,6 +441,12 @@ exports.setSchema = function (schema) {
       return _del(type, obj);
     });
   }
+  
+  function query(type, fun, options) {
+    return Promise.resolve().then(function () {
+      return _query(type, fun, options);
+    });
+  }
 
   function parseDocID(str) {
     var idx = str.indexOf('_');
@@ -446,7 +487,8 @@ exports.setSchema = function (schema) {
     putAttachment: putAttachment,
     removeAttachment: removeAttachment,
     parseDocID: parseDocID,
-    makeDocID: makeDocID
+    makeDocID: makeDocID,
+    query: query
   };
 };
 


### PR DESCRIPTION
I broke this commit out from https://github.com/nolanlawson/relational-pouch/pull/40
so that we could discuss it in a new issue.

Again, I'm hesitant to add map/reduce unless absolutely necessary; I think
we could just bundle the `pouchdb-find` plugin into this plugin (PouchDB plugins
can include other plugins) and then proxy to that. map/reduce is quasi-deprecated
and should be replaced by pouchb-find where possible.