### PR TITLE
Add glue for pouchdb-find methods: query, createIndex, deleteIndex, and getIndexes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ API
 * [`db.rel.find(type, id)`](#dbrelfindtype-id)
 * [`db.rel.find(type, ids)`](#dbrelfindtype-ids)
 * [`db.rel.find(type, options)`](#dbrelfindtype-options)
+* [`db.rel.query(type, query)`](#dbrelquerytype-query)
+* [`db.rel.createIndex(index)`](#dbrelcreateindexindex)
+* [`db.rel.getIndexes()`](#dbrelgetindexes)
+* [`db.rel.deleteIndex(index)`](#dbreldeleteindexindex)
 * [`db.rel.del(type, object)`](#dbreldeltype-object)
 * [`db.rel.putAttachment(type, object, attachmentId, attachment, attachmentType)`](#dbrelputattachmenttype-object-attachmentid-attachment-attachmenttype)
 * [`db.rel.getAttachment(type, id, attachmentId)`](#dbrelgetattachmenttype-id-attachmentid)
@@ -320,6 +324,59 @@ The following options based on the options for [PouchDB batch fetch](http://pouc
 * `startkey` & `endkey`:  Get documents with IDs in a certain range (inclusive/inclusive).
 * `limit`: Maximum number of documents to return.
 * `skip`: Number of docs to skip before returning (warning: poor performance on IndexedDB/LevelDB!).
+
+# db.rel.query(type, query)
+
+Requires the [pouchdb-find](https://github.com/nolanlawson/pouchdb-find) plugin.
+
+This maps to the `db.find` method provided by the `pouchdb-find` plugin. See [pouchdb-find](https://github.com/nolanlawson/pouchdb-find) for more information on how to construct queries.
+
+```js
+db.rel.query("post", {
+  selector: {
+    title: "Rails is Unagi"
+  }
+});
+```
+
+# db.rel.createIndex(index)
+
+Requires the [pouchdb-find](https://github.com/nolanlawson/pouchdb-find) plugin.
+
+This maps to the `db.createIndex` method provided by the `pouchdb-find` plugin. See [pouchdb-find](https://github.com/nolanlawson/pouchdb-find) for more information on how to construct an index.
+
+```js
+db.rel.createIndex({
+  index: {
+    fields: ['title']
+  }
+});
+```
+
+# db.rel.getIndexes()
+
+Requires the [pouchdb-find](https://github.com/nolanlawson/pouchdb-find) plugin.
+
+This maps to the `db.getIndexes` method provided by the `pouchdb-find` plugin. See [pouchdb-find](https://github.com/nolanlawson/pouchdb-find) for more information.
+
+```js
+db.rel.getIndexes().then(function (indexes) {
+  console.log(indexes);
+});
+```
+
+# db.rel.deleteIndex(index)
+
+Requires the [pouchdb-find](https://github.com/nolanlawson/pouchdb-find) plugin.
+
+This maps to the `db.deleteIndex` method provided by the `pouchdb-find` plugin. See [pouchdb-find](https://github.com/nolanlawson/pouchdb-find) for more information on how to delete an index.
+
+```js
+db.rel.getIndexes().then(function (indexes) {
+  var indexToDelete = indexes[1];
+  db.rel.deleteIndex(indexToDelete);
+});
+```
 
 ### db.rel.del(type, object)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -407,6 +407,77 @@ exports.setSchema = function (schema) {
     });
   }
 
+  function createIndex(index) {
+    return db.createIndex(transformIndexOrRequest(index));
+  }
+
+  function deleteIndex(index) {
+    return db.deleteIndex(index);
+  }
+
+  function getIndexes() {
+    return db.getIndexes();
+  }
+
+  function query(type, request) {
+    return db.find(transformIndexOrRequest(request)).then(function (results) {
+      var ids = results.docs.map(function (result) {
+        return parseDocID(result['_id']).id;
+      });
+      return _find(type, ids, new collections.Map());
+    });
+  }
+
+  function transformIndexOrRequest(indexOrRequest) {
+    var copy = extend(true, {}, indexOrRequest);
+    var obj = copy.index || copy;
+
+    var ignoreList = ['_id', '_rev', '$text'];
+    function shouldIgnore(field) {
+      return ignoreList.indexOf(field) !== -1;
+    }
+    function transform(field) {
+      return shouldIgnore(field) ? field : 'data.' + field;
+    }
+
+    if ('fields' in obj) {
+      obj.fields = obj.fields.map(function (field) {
+        if (typeof field === 'string') {
+          return transform(field);
+        } else {
+          field.name = transform(field.name);
+          return field;
+        }
+      });
+    }
+
+    if ('sort' in obj) {
+      obj.sort = obj.sort.map(function (field) {
+        if (typeof field === 'string') {
+          return transform(field);
+        } else {
+          var key = Object.keys(field)[0];
+          if (!shouldIgnore(key)) {
+            field['data.' + key] = field[key];
+            delete field[key];
+          }
+          return field;
+        }
+      });
+    }
+
+    if ('selector' in obj) {
+      Object.keys(obj.selector).forEach(function (field) {
+        if (!shouldIgnore(field)) {
+          obj.selector['data.' + field] = obj.selector[field];
+          delete obj.selector[field];
+        }
+      });
+    }
+
+    return copy;
+  }
+
   function parseDocID(str) {
     var idx = str.indexOf('_');
     var type = str.substring(0, idx);
@@ -445,6 +516,10 @@ exports.setSchema = function (schema) {
     getAttachment: getAttachment,
     putAttachment: putAttachment,
     removeAttachment: removeAttachment,
+    createIndex: createIndex,
+    getIndexes: getIndexes,
+    deleteIndex: deleteIndex,
+    query: query,
     parseDocID: parseDocID,
     makeDocID: makeDocID
   };

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mocha": "~1.18",
     "phantomjs": "^1.9.7-5",
     "pouchdb": "5.3.2",
+    "pouchdb-find": "^0.9.0",
     "request": "^2.36.0",
     "sauce-connect-launcher": "^0.4.2",
     "selenium-standalone": "^3.0.2",


### PR DESCRIPTION
Rebased version of #47.