### PR TITLE
Resolve failing tests when CouchDB _changes is not sorted as expected

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -2142,7 +2142,8 @@ function tests(dbName, dbType) {
           return db.rel.parseDocID(change.id);
         });
       }).then(function (res) {
-        res.should.deep.equal([
+        res.should.have.lengthOf(4);
+        res.should.deep.include.members([
           {"type": "author", "id": 19},
           {"type": "book", "id": 1},
           {"type": "book", "id": 2},


### PR DESCRIPTION
CouchDB (2.0) does not always return the change log in the order they were committed:

> The results returned by _changes are partially ordered. In other words, the order is not guaranteed to be preserved for multiple calls.
_http://docs.couchdb.org/en/2.0.0/api/database/changes.html_

This causes the following test failure: 

```
 1) http: relational tests fromRawDoc works with changes:

     AssertionError: expected [ Array(4) ] to deeply equal [ Array(4) ]
     + expected - actual

      [
        {
     +    "id": 19
     +    "type": "author"
     +  }
     +  {
          "id": 1
          "type": "book"
        }
        {
     -    "id": 19
     -    "type": "author"
     -  }
     -  {
          "id": 2
          "type": "book"
        }
```

This patch resolves this failure.

